### PR TITLE
Adding the regular .js file back into the installed package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "main": "jquery.ui.autocomplete.scroll.min.js",
   "files": [
+    "jquery.ui.autocomplete.scroll.js",
     "jquery.ui.autocomplete.scroll.min.js",
     "bower.json",
     "ui.autocomplete.scroll.jquery.json",


### PR DESCRIPTION
The installed package should still include the regular .js file. It was included before and some people might have it referenced instead of the minified js file. 